### PR TITLE
fix: use dirname of .xcodeproj as scope root in safety validation

### DIFF
--- a/src/core/safety.ts
+++ b/src/core/safety.ts
@@ -3,7 +3,7 @@
 // Prevents infinite loops, scope violations, and unsafe patches
 // ============================================================
 
-import { resolve, relative, isAbsolute } from "path";
+import { resolve, relative, isAbsolute, dirname } from "path";
 import { logger } from "../utils/logger.js";
 import type { BuildDiagnostic, Fix, SafetyCheckResult, LoopDetectionState } from "../types.js";
 import { diagnosticsSignature } from "./error-parser.js";
@@ -126,7 +126,11 @@ export function isWithinProjectScope(
   }
 
   const resolvedFile = resolve(filePath);
-  const resolvedProject = resolve(projectPath);
+  // project_path may be a .xcodeproj/.xcworkspace file — use its parent directory as scope root
+  const resolvedProjectPath = resolve(projectPath);
+  const resolvedProject = resolvedProjectPath.endsWith(".xcodeproj") || resolvedProjectPath.endsWith(".xcworkspace")
+    ? dirname(resolvedProjectPath)
+    : resolvedProjectPath;
 
   const rel = relative(resolvedProject, resolvedFile);
 


### PR DESCRIPTION
## Summary

- `isWithinProjectScope` was rejecting all fixes because it computed relative paths from the `.xcodeproj` file itself instead of its parent directory
- Source files are siblings of `.xcodeproj`, so the relative path always started with `../` and failed the scope check
- Fix: use `dirname(projectPath)` when `projectPath` ends with `.xcodeproj` or `.xcworkspace`

## Test Results

Tested on `XcodeAutoPilotTest` with 4 intentional errors:
- `autopilot_build` → detected 4 errors with source context ✅
- `autopilot_apply_fixes` → 5 fixes applied, 0 skipped ✅
- `autopilot_build` → **0 errors** ✅

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)