### PR TITLE
feat: add autopilot_resolve_spm tool

### DIFF
--- a/src/core/error-parser.ts
+++ b/src/core/error-parser.ts
@@ -27,6 +27,98 @@ const GENERIC_ERROR_REGEX = /^(error|warning):\s+(.+)$/;
 const BUILD_FAILED_REGEX = /^\*\* BUILD FAILED \*\*$/;
 
 // ----------------------------------------------------------
+// SPM-specific patterns
+// ----------------------------------------------------------
+
+// "error: Dependencies could not be resolved because no versions of 'Pkg' match ..."
+const SPM_VERSION_CONFLICT_REGEX =
+  /error:\s+Dependencies could not be resolved because no versions? of '(.+?)' match/i;
+
+// "error: 'Pkg' {ver} is required, but only versions {list} are available"
+const SPM_VERSION_REQUIRED_REGEX =
+  /error:\s+'(.+?)'\s+.+?\s+is required,\s+but only versions?\s+(.+?)\s+(?:is|are) available/i;
+
+// "error: failed to clone {url}: ..."
+const SPM_CLONE_FAILED_REGEX =
+  /error:\s+failed to clone\s+'?(.+?)'?:\s+(.+)$/i;
+
+// "error: package at '...' requires Swift X.X or later"
+const SPM_SWIFT_VERSION_REGEX =
+  /error:\s+package at '(.+?)'.+requires Swift (.+?) or later/i;
+
+// "xcodebuild: error: Could not resolve package dependencies"
+const SPM_COULD_NOT_RESOLVE_REGEX =
+  /error:\s+Could not resolve package dependencies/i;
+
+export interface SpmDiagnostic {
+  type: "version_conflict" | "version_required" | "clone_failed" | "swift_version" | "unresolvable" | "generic";
+  package?: string;
+  message: string;
+  raw_output: string;
+}
+
+export function parseSpmOutput(output: string): SpmDiagnostic[] {
+  const lines = output.split("\n");
+  const diagnostics: SpmDiagnostic[] = [];
+  const seen = new Set<string>();
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const versionConflict = trimmed.match(SPM_VERSION_CONFLICT_REGEX);
+    if (versionConflict) {
+      const key = `version_conflict:${versionConflict[1]}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        diagnostics.push({ type: "version_conflict", package: versionConflict[1], message: trimmed.replace(/^.*?error:\s+/, ""), raw_output: line });
+      }
+      continue;
+    }
+
+    const versionRequired = trimmed.match(SPM_VERSION_REQUIRED_REGEX);
+    if (versionRequired) {
+      const key = `version_required:${versionRequired[1]}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        diagnostics.push({ type: "version_required", package: versionRequired[1], message: trimmed.replace(/^.*?error:\s+/, ""), raw_output: line });
+      }
+      continue;
+    }
+
+    const cloneFailed = trimmed.match(SPM_CLONE_FAILED_REGEX);
+    if (cloneFailed) {
+      const key = `clone_failed:${cloneFailed[1]}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        diagnostics.push({ type: "clone_failed", package: cloneFailed[1], message: `Failed to clone '${cloneFailed[1]}': ${cloneFailed[2]}`, raw_output: line });
+      }
+      continue;
+    }
+
+    const swiftVersion = trimmed.match(SPM_SWIFT_VERSION_REGEX);
+    if (swiftVersion) {
+      const key = `swift_version:${swiftVersion[1]}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        diagnostics.push({ type: "swift_version", package: swiftVersion[1], message: `Package requires Swift ${swiftVersion[2]} or later`, raw_output: line });
+      }
+      continue;
+    }
+
+    if (SPM_COULD_NOT_RESOLVE_REGEX.test(trimmed)) {
+      const key = "unresolvable";
+      if (!seen.has(key)) {
+        seen.add(key);
+        diagnostics.push({ type: "unresolvable", message: "Could not resolve package dependencies", raw_output: line });
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+// ----------------------------------------------------------
 // Parser
 // ----------------------------------------------------------
 

--- a/src/core/xcodebuild.ts
+++ b/src/core/xcodebuild.ts
@@ -198,20 +198,44 @@ export async function listSchemes(projectPath: string): Promise<string[]> {
 // Resolve SPM dependencies
 // ----------------------------------------------------------
 
+export interface SpmResolveResult {
+  success: boolean;
+  raw_output: string;
+  duration_seconds: number;
+  exit_code: number;
+}
+
 export async function resolvePackageDependencies(
   projectPath: string,
   scheme: string
-): Promise<void> {
+): Promise<SpmResolveResult> {
   const flag = projectFlag(projectPath);
   const cmd = `xcodebuild ${flag} "${projectPath}" -scheme "${scheme}" -resolvePackageDependencies 2>&1`;
 
-  logger.info("Resolving package dependencies...");
+  logger.info("Resolving SPM dependencies...");
+  const startTime = Date.now();
+
+  let rawOutput = "";
+  let exitCode = 0;
 
   try {
-    await execAsync(cmd, { timeout: BUILD_TIMEOUT_MS });
-    logger.info("Package dependencies resolved.");
+    const result = await execAsync(cmd, { timeout: BUILD_TIMEOUT_MS });
+    rawOutput = result.stdout;
+    logger.info("SPM dependencies resolved successfully.");
   } catch (err: unknown) {
-    const execErr = err as { message?: string };
-    logger.warn(`Package resolution warning: ${execErr.message ?? String(err)}`);
+    const execErr = err as { stdout?: string; stderr?: string; code?: number; killed?: boolean };
+    if (execErr.killed) {
+      throw new Error(`xcodebuild -resolvePackageDependencies timed out after ${BUILD_TIMEOUT_MS / 1000}s`);
+    }
+    rawOutput = (execErr.stdout ?? "") + (execErr.stderr ?? "");
+    exitCode = execErr.code ?? 1;
+    logger.warn(`SPM resolution failed (exit code ${exitCode})`);
   }
+
+  return {
+    success: exitCode === 0,
+    raw_output: rawOutput,
+    duration_seconds: (Date.now() - startTime) / 1000,
+    exit_code: exitCode,
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { logger } from "./utils/logger.js";
 // Tool handlers
 import { handleAutopilotBuild, autopilotBuildSchema } from "./tools/autopilot-build.js";
 import { handleAutopilotApplyFixes, autopilotApplyFixesSchema } from "./tools/autopilot-apply-fixes.js";
+import { handleAutopilotResolveSpm, autopilotResolveSpmSchema } from "./tools/autopilot-resolve-spm.js";
 import { handleListSchemes, listSchemesSchema } from "./tools/list-schemes.js";
 import { handleClean, cleanSchema } from "./tools/clean.js";
 import { handleHistory } from "./tools/history.js";
@@ -37,6 +38,14 @@ const TOOLS = [
       "the original line content (for verification), and the replacement. Files are backed up before " +
       "modification and scope-checked against the project path.",
     inputSchema: zodToJsonSchema(autopilotApplyFixesSchema),
+  },
+  {
+    name: "autopilot_resolve_spm",
+    description:
+      "Run xcodebuild -resolvePackageDependencies and return structured SPM errors " +
+      "(version conflicts, clone failures, Swift version mismatches). " +
+      "Use this when a build fails due to missing or unresolvable packages.",
+    inputSchema: zodToJsonSchema(autopilotResolveSpmSchema),
   },
   {
     name: "autopilot_list_schemes",
@@ -134,6 +143,11 @@ export function createServer(): Server {
         case "autopilot_apply_fixes": {
           const parsed = autopilotApplyFixesSchema.parse(args);
           result = await handleAutopilotApplyFixes(parsed);
+          break;
+        }
+        case "autopilot_resolve_spm": {
+          const parsed = autopilotResolveSpmSchema.parse(args);
+          result = await handleAutopilotResolveSpm(parsed);
           break;
         }
         case "autopilot_list_schemes": {

--- a/src/tools/autopilot-resolve-spm.ts
+++ b/src/tools/autopilot-resolve-spm.ts
@@ -1,0 +1,46 @@
+// ============================================================
+// XcodeAutoPilot — autopilot_resolve_spm Tool
+// Resolves SPM dependencies and returns structured errors
+// ============================================================
+
+import { z } from "zod";
+import { resolvePackageDependencies } from "../core/xcodebuild.js";
+import { parseSpmOutput } from "../core/error-parser.js";
+import { logger } from "../utils/logger.js";
+
+export const autopilotResolveSpmSchema = z.object({
+  project_path: z.string().describe("Absolute path to .xcodeproj or .xcworkspace"),
+  scheme: z.string().describe("Build scheme name"),
+});
+
+export type AutopilotResolveSpmInput = z.infer<typeof autopilotResolveSpmSchema>;
+
+export async function handleAutopilotResolveSpm(
+  input: AutopilotResolveSpmInput
+): Promise<string> {
+  logger.info(`autopilot_resolve_spm: ${input.project_path} [${input.scheme}]`);
+
+  const result = await resolvePackageDependencies(input.project_path, input.scheme);
+  const errors = parseSpmOutput(result.raw_output);
+
+  const summary = result.success
+    ? `SPM dependencies resolved successfully in ${result.duration_seconds.toFixed(1)}s.`
+    : `SPM resolution failed in ${result.duration_seconds.toFixed(1)}s — ${errors.length} error(s) found.`;
+
+  return JSON.stringify(
+    {
+      success: result.success,
+      summary,
+      error_count: errors.length,
+      errors: errors.map((e) => ({
+        type: e.type,
+        package: e.package ?? null,
+        message: e.message,
+      })),
+      duration_seconds: result.duration_seconds,
+      raw_output_preview: result.raw_output.split("\n").slice(-30).join("\n"),
+    },
+    null,
+    2
+  );
+}


### PR DESCRIPTION
## Summary

- Add `autopilot_resolve_spm` tool — runs `xcodebuild -resolvePackageDependencies` and returns structured SPM errors
- SPM-specific error parser with 5 error types: `version_conflict`, `version_required`, `clone_failed`, `swift_version`, `unresolvable`
- Updated `resolvePackageDependencies` in `xcodebuild.ts` to return structured results instead of swallowing errors

## Test Results

Tested on `XcodeAutoPilotTest` (no SPM deps):
- `autopilot_resolve_spm` → success, 0 errors, 1.7s ✅

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)