### PR TITLE
feat: add xap keyword trigger system

### DIFF
--- a/claude/hooks/keyword-detector.mjs
+++ b/claude/hooks/keyword-detector.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// ============================================================
+// XAP — Keyword Detector Hook
+// UserPromptSubmit hook: detects xap keywords and injects
+// orchestration instructions into Claude's context.
+// ============================================================
+
+import { readFileSync } from "fs";
+
+// ----------------------------------------------------------
+// Keyword patterns
+// ----------------------------------------------------------
+
+const PATTERNS = [
+  {
+    key: "xap-build",
+    regex: /\b(xbuild|xap[\s-]build)\b/i,
+    priority: 1,
+  },
+  {
+    key: "xap-fix",
+    regex: /\b(xfix|xap[\s-]fix)\b/i,
+    priority: 2,
+  },
+  {
+    key: "xap-clean",
+    regex: /\b(xclean|xap[\s-]clean)\b/i,
+    priority: 3,
+  },
+  {
+    key: "xap-spm",
+    regex: /\b(xspm|xap[\s-]spm)\b/i,
+    priority: 4,
+  },
+];
+
+// ----------------------------------------------------------
+// Context messages per keyword
+// ----------------------------------------------------------
+
+const CONTEXTS = {
+  "xap-build": `
+[XAP KEYWORD DETECTED: XBUILD]
+
+You MUST immediately execute the xap-build workflow using the MCP tools:
+
+1. If project_path or scheme are not clear from context, ask the user before proceeding.
+2. Call \`autopilot_build\` to get current errors with source context.
+3. Analyze all errors using the returned source context (±50 lines).
+4. Call \`autopilot_apply_fixes\` with a fix for every fixable error.
+5. Repeat steps 2–4 until 0 errors remain or 5 iterations are exhausted.
+6. Report a summary: how many errors fixed, which files changed, any unfixable errors.
+
+Do not ask for permission between steps. Execute the full loop autonomously.
+`.trim(),
+
+  "xap-fix": `
+[XAP KEYWORD DETECTED: XFIX]
+
+You MUST immediately execute the xap-fix workflow using the MCP tools:
+
+1. If project_path or scheme are not clear from context, ask the user before proceeding.
+2. Call \`autopilot_build\` to get the current error list with source context.
+3. Carefully analyze each error using the ±50 line source context provided.
+4. Call \`autopilot_apply_fixes\` with precise fixes for all fixable errors.
+5. Call \`autopilot_build\` again to verify — repeat if errors remain (max 5 iterations).
+6. Report what was fixed and flag any errors you could not fix with reasons.
+
+Do not ask for permission between steps. Execute the full loop autonomously.
+`.trim(),
+
+  "xap-clean": `
+[XAP KEYWORD DETECTED: XCLEAN]
+
+You MUST immediately execute the xap-clean workflow using the MCP tools:
+
+1. If project_path is not clear from context, ask the user before proceeding.
+2. Ask the user which scope to clean if not specified:
+   - \`project\` — DerivedData for this project (most common)
+   - \`module_cache\` — Xcode ModuleCache.noindex
+   - \`spm\` — SPM fetch cache + SourcePackages
+   - \`index\` — Index store
+   - \`all\` — everything above
+   Default to \`project\` if the user says "clean" without a scope.
+3. Call \`autopilot_cache_clean\` with the chosen scope.
+4. Call \`autopilot_build\` to confirm the project still builds after cleaning.
+5. Report what was deleted, space freed, and build result.
+
+Do not ask for permission between steps. Execute the full workflow autonomously.
+`.trim(),
+
+  "xap-spm": `
+[XAP KEYWORD DETECTED: XSPM]
+
+You MUST immediately execute the xap-spm workflow using the MCP tools:
+
+1. If project_path or scheme are not clear from context, ask the user before proceeding.
+2. Call \`autopilot_resolve_spm\` to resolve package dependencies.
+3. If SPM resolution fails or errors remain:
+   a. Call \`autopilot_cache_clean\` with scope \`spm\` to nuke the SPM cache.
+   b. Call \`autopilot_resolve_spm\` again.
+4. Call \`autopilot_build\` to confirm the project builds cleanly after SPM resolution.
+5. If build errors remain after SPM is resolved, call \`autopilot_apply_fixes\` as needed.
+6. Report SPM resolution result, any packages that changed, and final build status.
+
+Do not ask for permission between steps. Execute the full workflow autonomously.
+`.trim(),
+};
+
+// ----------------------------------------------------------
+// Stdin reading
+// ----------------------------------------------------------
+
+function readStdin() {
+  try {
+    return readFileSync("/dev/stdin", "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function extractPrompt(data) {
+  if (typeof data.prompt === "string") return data.prompt;
+  if (typeof data.message?.content === "string") return data.message.content;
+  if (Array.isArray(data.parts)) {
+    return data.parts
+      .filter((p) => p.type === "text")
+      .map((p) => p.text)
+      .join(" ");
+  }
+  return "";
+}
+
+function sanitize(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")  // code blocks
+    .replace(/`[^`]*`/g, " ")         // inline code
+    .replace(/https?:\/\/\S+/g, " ")  // URLs
+    .replace(/<[^>]+>/g, " ");        // XML/HTML tags
+}
+
+// ----------------------------------------------------------
+// Main
+// ----------------------------------------------------------
+
+const raw = readStdin();
+if (!raw) process.exit(0);
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+const prompt = extractPrompt(data);
+if (!prompt) process.exit(0);
+
+const clean = sanitize(prompt);
+
+// Match in priority order, pick first hit
+let detected = null;
+for (const pattern of PATTERNS) {
+  if (pattern.regex.test(clean)) {
+    detected = pattern.key;
+    break;
+  }
+}
+
+if (!detected) process.exit(0);
+
+const context = CONTEXTS[detected];
+const output = {
+  continue: true,
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    additionalContext: context,
+  },
+};
+
+process.stdout.write(JSON.stringify(output));

--- a/claude/skills/xap-build/SKILL.md
+++ b/claude/skills/xap-build/SKILL.md
@@ -1,0 +1,49 @@
+---
+id: xap-build
+name: xap-build
+description: Build an Xcode project and automatically fix all errors in a loop using XcodeAutoPilot MCP tools.
+triggers:
+  - xbuild
+  - xap build
+tags:
+  - xcode
+  - build
+  - autopilot
+  - fix
+source: manual
+---
+
+# xap-build
+
+Trigger with: **`xbuild`** or **`xap build`**
+
+## What it does
+
+Runs the full build → analyze → fix loop using XcodeAutoPilot MCP tools:
+
+1. `autopilot_build` — compile and collect structured errors with ±50 line source context
+2. Analyze errors using the source context
+3. `autopilot_apply_fixes` — apply precise fixes (verified by original line content)
+4. Repeat until 0 errors or 5 iterations exhausted
+
+## Required inputs
+
+- `project_path` — absolute path to `.xcodeproj` or `.xcworkspace`
+- `scheme` — Xcode build scheme name
+
+## Tool sequence
+
+```
+autopilot_build(project_path, scheme)
+  → errors > 0 → autopilot_apply_fixes(project_path, fixes[])
+  → autopilot_build(project_path, scheme)
+  → ... repeat up to 5x
+  → report summary
+```
+
+## Notes
+
+- Each fix must include `file_path`, `line_number`, `original_line`, `fixed_line`, `explanation`
+- `original_line` is verified before patching — must match exactly
+- Files are backed up before modification
+- Use `autopilot_cache_clean` first if build fails for non-code reasons

--- a/claude/skills/xap-clean/SKILL.md
+++ b/claude/skills/xap-clean/SKILL.md
@@ -1,0 +1,50 @@
+---
+id: xap-clean
+name: xap-clean
+description: Clear Xcode caches (DerivedData, ModuleCache, SPM, Index) and verify the project still builds.
+triggers:
+  - xclean
+  - xap clean
+tags:
+  - xcode
+  - cache
+  - clean
+  - derived-data
+source: manual
+---
+
+# xap-clean
+
+Trigger with: **`xclean`** or **`xap clean`**
+
+## What it does
+
+Clears Xcode caches that `xcodebuild clean` doesn't touch, then verifies the build:
+
+1. `autopilot_cache_clean` — remove selected cache scope
+2. `autopilot_build` — confirm project builds after cleaning
+
+## Scope options
+
+| scope | Clears |
+|-------|--------|
+| `project` | `DerivedData/<ProjectName>-*` (default) |
+| `module_cache` | `DerivedData/ModuleCache.noindex` |
+| `spm` | `Caches/org.swift.swiftpm` + `SourcePackages` |
+| `index` | `DerivedData/.../Index.noindex` |
+| `all` | Everything above |
+
+**Default scope:** `project` (safest, fastest rebuild)
+
+## When to use each scope
+
+- Unexplained build failures → `project`
+- "Module not found" after renaming → `module_cache`
+- SPM packages broken/stale → `spm`
+- Indexing broken or slow → `index`
+- Everything is broken → `all`
+
+## Required inputs
+
+- `project_path` — absolute path to `.xcodeproj` or `.xcworkspace`
+- `scheme` — needed for the verification build

--- a/claude/skills/xap-fix/SKILL.md
+++ b/claude/skills/xap-fix/SKILL.md
@@ -1,0 +1,49 @@
+---
+id: xap-fix
+name: xap-fix
+description: Fix current Xcode build errors using XcodeAutoPilot MCP tools with deep source context analysis.
+triggers:
+  - xfix
+  - xap fix
+tags:
+  - xcode
+  - fix
+  - autopilot
+source: manual
+---
+
+# xap-fix
+
+Trigger with: **`xfix`** or **`xap fix`**
+
+## What it does
+
+Focuses on fixing errors with careful analysis of source context:
+
+1. `autopilot_build` — get errors with full ±50 line context
+2. Read and understand the surrounding code before generating fixes
+3. `autopilot_apply_fixes` — apply fixes verified against original line content
+4. Verify with another `autopilot_build` — repeat if needed (max 5 iterations)
+
+## Difference from xap-build
+
+`xap-fix` emphasizes careful error analysis over speed. Use when:
+- Errors are complex (type mismatches, API changes, protocol conformance)
+- Previous fix attempts introduced new errors
+- You want higher confidence fixes before applying
+
+## Required inputs
+
+- `project_path` — absolute path to `.xcodeproj` or `.xcworkspace`
+- `scheme` — Xcode build scheme name
+
+## Tool sequence
+
+```
+autopilot_build(project_path, scheme)
+  → analyze each error + source context carefully
+  → autopilot_apply_fixes(project_path, fixes[])
+  → autopilot_build(project_path, scheme)  ← verify
+  → repeat if errors remain (max 5x)
+  → report: fixed / unfixable / remaining
+```

--- a/claude/skills/xap-spm/SKILL.md
+++ b/claude/skills/xap-spm/SKILL.md
@@ -1,0 +1,52 @@
+---
+id: xap-spm
+name: xap-spm
+description: Resolve SPM dependency issues and verify the build using XcodeAutoPilot MCP tools.
+triggers:
+  - xspm
+  - xap spm
+tags:
+  - xcode
+  - spm
+  - swift-package-manager
+  - dependencies
+source: manual
+---
+
+# xap-spm
+
+Trigger with: **`xspm`** or **`xap spm`**
+
+## What it does
+
+Full SPM issue resolution workflow:
+
+1. `autopilot_resolve_spm` — run `xcodebuild -resolvePackageDependencies`
+2. If resolution fails → `autopilot_cache_clean(scope: "spm")` → retry resolution
+3. `autopilot_build` — verify project builds after SPM is resolved
+4. If build errors remain → `autopilot_apply_fixes` as needed
+
+## Common SPM problems this handles
+
+- Version conflicts between packages
+- Clone failures (network/cache issues)
+- Swift version mismatches
+- Stale `Package.resolved` lock causing conflicts
+- SourcePackages folder corrupted
+
+## Required inputs
+
+- `project_path` — absolute path to `.xcodeproj` or `.xcworkspace`
+- `scheme` — Xcode build scheme name
+
+## Tool sequence
+
+```
+autopilot_resolve_spm(project_path, scheme)
+  → if failed:
+      autopilot_cache_clean(project_path, scope="spm")
+      autopilot_resolve_spm(project_path, scheme)  ← retry
+  → autopilot_build(project_path, scheme)  ← verify
+  → if build errors: autopilot_apply_fixes(...)
+  → report final status
+```

--- a/scripts/install-xap.sh
+++ b/scripts/install-xap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ============================================================
+# XAP — Install Script
+# Registers the xap keyword-detector hook in ~/.claude/settings.json
+# and copies skills to ~/.claude/skills/
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK_SRC="$REPO_ROOT/claude/hooks/keyword-detector.mjs"
+SKILLS_SRC="$REPO_ROOT/claude/skills"
+CLAUDE_DIR="$HOME/.claude"
+SKILLS_DST="$CLAUDE_DIR/skills"
+SETTINGS="$CLAUDE_DIR/settings.json"
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log()  { echo -e "${CYAN}[xap]${NC} $*"; }
+ok()   { echo -e "${GREEN}[xap]${NC} $*"; }
+warn() { echo -e "${YELLOW}[xap]${NC} $*"; }
+err()  { echo -e "${RED}[xap]${NC} $*"; exit 1; }
+
+# ----------------------------------------------------------
+# Preflight checks
+# ----------------------------------------------------------
+
+[[ -f "$HOOK_SRC" ]] || err "Hook not found: $HOOK_SRC"
+command -v node >/dev/null 2>&1 || err "Node.js is required but not installed."
+command -v jq >/dev/null 2>&1   || err "jq is required but not installed. Run: brew install jq"
+
+mkdir -p "$CLAUDE_DIR"
+
+# ----------------------------------------------------------
+# Copy skills
+# ----------------------------------------------------------
+
+log "Installing skills to $SKILLS_DST ..."
+mkdir -p "$SKILLS_DST"
+
+for skill_dir in "$SKILLS_SRC"/*/; do
+  skill_name="$(basename "$skill_dir")"
+  dst="$SKILLS_DST/$skill_name"
+  mkdir -p "$dst"
+  cp "$skill_dir/SKILL.md" "$dst/SKILL.md"
+  ok "  Installed skill: $skill_name"
+done
+
+# ----------------------------------------------------------
+# Register hook in settings.json
+# ----------------------------------------------------------
+
+HOOK_CMD="node \"$HOOK_SRC\""
+
+log "Registering hook in $SETTINGS ..."
+
+# Create settings.json if it doesn't exist
+if [[ ! -f "$SETTINGS" ]]; then
+  echo '{}' > "$SETTINGS"
+fi
+
+# Check if hook is already registered
+if jq -e --arg cmd "$HOOK_CMD" \
+  '.hooks.UserPromptSubmit[]?.hooks[]? | select(.command == $cmd)' \
+  "$SETTINGS" >/dev/null 2>&1; then
+  warn "Hook already registered — skipping."
+else
+  # Build new hook entry
+  NEW_HOOK=$(jq -n --arg cmd "$HOOK_CMD" '{
+    matcher: "*",
+    hooks: [{
+      type: "command",
+      command: $cmd,
+      timeout: 5
+    }]
+  }')
+
+  # Merge into existing settings
+  UPDATED=$(jq --argjson entry "$NEW_HOOK" '
+    .hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [$entry])
+  ' "$SETTINGS")
+
+  echo "$UPDATED" > "$SETTINGS"
+  ok "Hook registered."
+fi
+
+# ----------------------------------------------------------
+# Done
+# ----------------------------------------------------------
+
+echo ""
+ok "XAP keyword triggers installed!"
+echo ""
+echo "  Available keywords:"
+echo "    xbuild  /  xap build  — build + fix loop"
+echo "    xfix    /  xap fix    — focused error fix"
+echo "    xclean  /  xap clean  — cache clean + verify"
+echo "    xspm    /  xap spm    — SPM resolve + verify"
+echo ""
+warn "Restart Claude Code to activate the hook."


### PR DESCRIPTION
## Summary
- `xap` 키워드 감지 시스템 추가 — 자연어 명령에서 키워드를 인식해 MCP 툴 오케스트레이션을 자동 실행
- OMC의 keyword-detector 구조를 참고해 XcodeAutoPilot 전용으로 구현

## 키워드 목록
| 키워드 | 별칭 | 동작 |
|--------|------|------|
| `xap build` | `xbuild` | `autopilot_build` → 에러 분석 → `autopilot_apply_fixes` 루프 |
| `xap fix` | `xfix` | 신중한 소스 분석 후 픽스 루프 |
| `xap clean` | `xclean` | `autopilot_cache_clean` → `autopilot_build` 검증 |
| `xap spm` | `xspm` | `autopilot_resolve_spm` → SPM 캐시 정리 → `autopilot_build` |

## 파일 구조
```
claude/
├── hooks/keyword-detector.mjs   # UserPromptSubmit 훅
└── skills/
    ├── xap-build/SKILL.md
    ├── xap-fix/SKILL.md
    ├── xap-clean/SKILL.md
    └── xap-spm/SKILL.md
scripts/
└── install-xap.sh               # ~/.claude/settings.json에 훅 등록 + 스킬 복사
```

## Test plan
- [x] `echo '{"prompt":"xbuild ..."}' | node claude/hooks/keyword-detector.mjs` → 올바른 context 반환
- [x] `xap spm` 한국어 혼합 문장에서도 감지 확인
- [ ] `scripts/install-xap.sh` 실행 후 Claude Code 재시작 → 실제 훅 동작 확인

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)