### PR TITLE
feat: add autopilot_tuist_build tool with version-aware commands

### DIFF
--- a/src/core/tuist.ts
+++ b/src/core/tuist.ts
@@ -1,0 +1,136 @@
+// ============================================================
+// XcodeAutoPilot — Tuist CLI Wrapper
+// Version-aware: Tuist 3.x (fetch/generate) vs 4.x (install/generate)
+// ============================================================
+
+import { exec } from "child_process";
+import { promisify } from "util";
+import { readdir } from "fs/promises";
+import { join } from "path";
+import { logger } from "../utils/logger.js";
+
+const execAsync = promisify(exec);
+
+const TUIST_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface TuistStepResult {
+  success: boolean;
+  raw_output: string;
+  duration_seconds: number;
+}
+
+export interface TuistGenerateResult extends TuistStepResult {
+  workspace_path: string | null;
+}
+
+// ----------------------------------------------------------
+// Version detection
+// ----------------------------------------------------------
+
+export async function getTuistMajorVersion(): Promise<number> {
+  try {
+    const { stdout } = await execAsync("tuist version", { timeout: 10_000 });
+    const match = stdout.trim().match(/^(\d+)\./);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+  } catch {
+    // tuist not found or failed
+  }
+  throw new Error("Could not detect Tuist version. Is Tuist installed? Run: curl -Ls https://install.tuist.io | bash");
+}
+
+// ----------------------------------------------------------
+// Dependency installation
+// ----------------------------------------------------------
+
+export async function tuistInstall(
+  projectDir: string,
+  majorVersion: number
+): Promise<TuistStepResult> {
+  // v4+: tuist install, v3.x: tuist fetch
+  const cmd = majorVersion >= 4 ? "tuist install" : "tuist fetch";
+  logger.info(`Tuist v${majorVersion}: running '${cmd}' in ${projectDir}`);
+
+  const startTime = Date.now();
+  let rawOutput = "";
+  let success = true;
+
+  try {
+    const result = await execAsync(cmd, {
+      cwd: projectDir,
+      timeout: TUIST_TIMEOUT_MS,
+    });
+    rawOutput = result.stdout + result.stderr;
+  } catch (err: unknown) {
+    const execErr = err as { stdout?: string; stderr?: string; killed?: boolean };
+    if (execErr.killed) {
+      throw new Error(`'${cmd}' timed out after ${TUIST_TIMEOUT_MS / 1000}s`);
+    }
+    rawOutput = (execErr.stdout ?? "") + (execErr.stderr ?? "");
+    success = false;
+  }
+
+  return {
+    success,
+    raw_output: rawOutput,
+    duration_seconds: (Date.now() - startTime) / 1000,
+  };
+}
+
+// ----------------------------------------------------------
+// Project generation
+// ----------------------------------------------------------
+
+export async function tuistGenerate(projectDir: string): Promise<TuistGenerateResult> {
+  const cmd = "tuist generate --no-open";
+  logger.info(`Tuist generate: running '${cmd}' in ${projectDir}`);
+
+  const startTime = Date.now();
+  let rawOutput = "";
+  let success = true;
+
+  try {
+    const result = await execAsync(cmd, {
+      cwd: projectDir,
+      timeout: TUIST_TIMEOUT_MS,
+    });
+    rawOutput = result.stdout + result.stderr;
+  } catch (err: unknown) {
+    const execErr = err as { stdout?: string; stderr?: string; killed?: boolean };
+    if (execErr.killed) {
+      throw new Error(`'${cmd}' timed out after ${TUIST_TIMEOUT_MS / 1000}s`);
+    }
+    rawOutput = (execErr.stdout ?? "") + (execErr.stderr ?? "");
+    success = false;
+  }
+
+  const duration = (Date.now() - startTime) / 1000;
+
+  // Find the generated .xcworkspace
+  const workspacePath = success ? await findGeneratedWorkspace(projectDir) : null;
+
+  return {
+    success,
+    raw_output: rawOutput,
+    duration_seconds: duration,
+    workspace_path: workspacePath,
+  };
+}
+
+// ----------------------------------------------------------
+// Workspace discovery (post-generate)
+// ----------------------------------------------------------
+
+async function findGeneratedWorkspace(projectDir: string): Promise<string | null> {
+  try {
+    const entries = await readdir(projectDir);
+    const workspace = entries.find((e) => e.endsWith(".xcworkspace"));
+    if (workspace) {
+      return join(projectDir, workspace);
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { handleListSchemes, listSchemesSchema } from "./tools/list-schemes.js";
 import { handleClean, cleanSchema } from "./tools/clean.js";
 import { handleHistory } from "./tools/history.js";
 import { handleCacheClean, cacheClearSchema } from "./tools/cache-clean.js";
+import { handleAutopilotTuistBuild, autopilotTuistBuildSchema } from "./tools/tuist-build.js";
 
 // ----------------------------------------------------------
 // Tool definitions (for ListTools response)
@@ -65,6 +66,15 @@ const TOOLS = [
       "Use 'project' to remove DerivedData for this project, 'module_cache' for ModuleCache.noindex, " +
       "'spm' for SPM fetch cache and SourcePackages, 'index' for the Index store, or 'all' for everything.",
     inputSchema: zodToJsonSchema(cacheClearSchema),
+  },
+  {
+    name: "autopilot_tuist_build",
+    description:
+      "Build a Tuist-managed Xcode project. Automatically detects Tuist version and runs the correct " +
+      "commands: v4+ uses 'tuist install' + 'tuist generate', v3.x uses 'tuist fetch' + 'tuist generate'. " +
+      "Then runs xcodebuild and returns structured errors with source context, same format as autopilot_build. " +
+      "Use skip_install or skip_generate to skip steps already completed.",
+    inputSchema: zodToJsonSchema(autopilotTuistBuildSchema),
   },
   {
     name: "autopilot_history",
@@ -172,6 +182,11 @@ export function createServer(): Server {
         case "autopilot_cache_clean": {
           const parsed = cacheClearSchema.parse(args);
           result = await handleCacheClean(parsed);
+          break;
+        }
+        case "autopilot_tuist_build": {
+          const parsed = autopilotTuistBuildSchema.parse(args);
+          result = await handleAutopilotTuistBuild(parsed);
           break;
         }
         case "autopilot_history": {

--- a/src/tools/tuist-build.ts
+++ b/src/tools/tuist-build.ts
@@ -1,0 +1,185 @@
+// ============================================================
+// XcodeAutoPilot — autopilot_tuist_build Tool
+// Runs tuist install/fetch + generate + xcodebuild (version-aware)
+// ============================================================
+
+import { z } from "zod";
+import { getTuistMajorVersion, tuistInstall, tuistGenerate } from "../core/tuist.js";
+import { runBuild, getDefaultDestination } from "../core/xcodebuild.js";
+import { filterErrors, filterWarnings } from "../core/error-parser.js";
+import { extractContextForDiagnostics } from "../utils/context-extractor.js";
+import { logger } from "../utils/logger.js";
+
+export const autopilotTuistBuildSchema = z.object({
+  project_directory: z
+    .string()
+    .describe("Absolute path to the directory containing Project.swift or Tuist/"),
+  scheme: z.string().describe("Build scheme name"),
+  configuration: z
+    .string()
+    .optional()
+    .default("Debug")
+    .describe("Build configuration (Debug or Release)"),
+  destination: z
+    .string()
+    .optional()
+    .describe("Build destination. Auto-detected if omitted."),
+  include_warnings: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Include warnings in context extraction (default: false)"),
+  skip_install: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Skip tuist install/fetch step (use if dependencies are already resolved)"),
+  skip_generate: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Skip tuist generate step (use if .xcworkspace already exists)"),
+  workspace_path: z
+    .string()
+    .optional()
+    .describe("Absolute path to existing .xcworkspace. Required when skip_generate=true."),
+});
+
+export type AutopilotTuistBuildInput = z.infer<typeof autopilotTuistBuildSchema>;
+
+export async function handleAutopilotTuistBuild(
+  input: AutopilotTuistBuildInput
+): Promise<string> {
+  const projectDir = input.project_directory;
+  logger.info(`autopilot_tuist_build: ${projectDir} [${input.scheme}]`);
+
+  const tuistSteps: Record<string, unknown> = {};
+
+  // Step 1: Detect Tuist version
+  let tuistVersion: number;
+  try {
+    tuistVersion = await getTuistMajorVersion();
+    logger.info(`Detected Tuist v${tuistVersion}`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return JSON.stringify({ success: false, error: message }, null, 2);
+  }
+
+  // Step 2: Install dependencies
+  if (!input.skip_install) {
+    const installResult = await tuistInstall(projectDir, tuistVersion);
+    tuistSteps["install"] = {
+      success: installResult.success,
+      duration_seconds: installResult.duration_seconds,
+    };
+    if (!installResult.success) {
+      return JSON.stringify(
+        {
+          success: false,
+          summary: `tuist ${tuistVersion >= 4 ? "install" : "fetch"} failed.`,
+          tuist_version: tuistVersion,
+          tuist_steps: tuistSteps,
+          raw_output: installResult.raw_output,
+        },
+        null,
+        2
+      );
+    }
+  }
+
+  // Step 3: Generate Xcode project
+  let resolvedWorkspacePath: string;
+
+  if (input.skip_generate) {
+    if (!input.workspace_path) {
+      return JSON.stringify(
+        {
+          success: false,
+          error: "workspace_path is required when skip_generate=true",
+        },
+        null,
+        2
+      );
+    }
+    resolvedWorkspacePath = input.workspace_path;
+  } else {
+    const generateResult = await tuistGenerate(projectDir);
+    tuistSteps["generate"] = {
+      success: generateResult.success,
+      workspace_path: generateResult.workspace_path,
+      duration_seconds: generateResult.duration_seconds,
+    };
+    if (!generateResult.success || !generateResult.workspace_path) {
+      return JSON.stringify(
+        {
+          success: false,
+          summary: generateResult.success
+            ? "tuist generate succeeded but no .xcworkspace found in project directory."
+            : "tuist generate failed.",
+          tuist_version: tuistVersion,
+          tuist_steps: tuistSteps,
+          raw_output: generateResult.raw_output,
+        },
+        null,
+        2
+      );
+    }
+    resolvedWorkspacePath = generateResult.workspace_path;
+  }
+
+  // Step 4: Build with xcodebuild
+  const destination = input.destination ?? (await getDefaultDestination());
+
+  const buildResult = await runBuild({
+    project_path: resolvedWorkspacePath,
+    scheme: input.scheme,
+    configuration: input.configuration,
+    destination,
+  });
+
+  const errors = filterErrors(buildResult.diagnostics);
+  const warnings = filterWarnings(buildResult.diagnostics);
+
+  const summary = buildResult.success
+    ? `Build succeeded in ${buildResult.duration_seconds.toFixed(1)}s — no errors.`
+    : `Build failed in ${buildResult.duration_seconds.toFixed(1)}s — ${errors.length} error(s), ${warnings.length} warning(s).`;
+
+  const diagnosticsForContext = input.include_warnings ? buildResult.diagnostics : errors;
+  const contextMap =
+    errors.length > 0 ? await extractContextForDiagnostics(diagnosticsForContext) : new Map();
+
+  const fileContexts = Array.from(contextMap.entries()).map(([filePath, ctx]) => ({
+    file_path: filePath,
+    error_lines: ctx.error_lines,
+    source: ctx.context_text,
+    start_line: ctx.start_line,
+    end_line: ctx.end_line,
+  }));
+
+  return JSON.stringify(
+    {
+      success: buildResult.success,
+      summary,
+      tuist_version: tuistVersion,
+      tuist_steps: tuistSteps,
+      workspace_path: resolvedWorkspacePath,
+      error_count: errors.length,
+      warning_count: warnings.length,
+      errors: errors.map((d) => ({
+        file: d.file_path,
+        line: d.line_number,
+        column: d.column_number,
+        message: d.message,
+      })),
+      warnings: warnings.map((d) => ({
+        file: d.file_path,
+        line: d.line_number,
+        message: d.message,
+      })),
+      file_contexts: fileContexts,
+      duration_seconds: buildResult.duration_seconds,
+    },
+    null,
+    2
+  );
+}


### PR DESCRIPTION
## Summary

- Tuist 프로젝트 빌드를 위한 `autopilot_tuist_build` MCP 툴 추가
- Tuist 버전 자동 감지 후 버전별 맞는 명령어 실행 (v3.x / v4.x)
- 기존 `autopilot_build` 인프라(error-parser, context-extractor) 재사용

## Version-aware flow

| Step | Tuist 3.x | Tuist 4.x |
|------|-----------|-----------|
| 의존성 설치 | `tuist fetch` | `tuist install` |
| 프로젝트 생성 | `tuist generate --no-open` | `tuist generate --no-open` |
| 빌드 | xcodebuild | xcodebuild |

## Files

- `src/core/tuist.ts` — Tuist CLI 래퍼 (버전 감지, install/fetch, generate, workspace 탐색)
- `src/tools/tuist-build.ts` — 툴 핸들러
- `src/server.ts` — 새 툴 등록

## Test plan

- [x] `npm run build` — TypeScript 컴파일 통과
- [x] `npm test` — 42/42 테스트 통과
- [ ] XcodeAutoPilotTest에서 Tuist 프로젝트로 `autopilot_tuist_build` 호출 검증

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)