### PR TITLE
feat: smart context extraction with enclosing scope, grep, and sourcekit-lsp

### DIFF
--- a/src/core/error-classifier.ts
+++ b/src/core/error-classifier.ts
@@ -1,0 +1,63 @@
+// ============================================================
+// XcodeAutoPilot — Swift Error Classifier
+// Parses Swift compiler error messages to extract relevant symbols
+// for targeted context lookup (grep / sourcekit-lsp).
+// ============================================================
+
+export type ErrorClass =
+  | { kind: "missing_member"; symbol: string }   // "has no member 'X'" → look up type X
+  | { kind: "unresolved";     symbol: string }   // "unresolved identifier 'X'" → look up X
+  | { kind: "type_mismatch";  symbol: string | null } // "cannot convert..." → look up call site
+  | { kind: "missing_label";  symbol: string }   // "missing argument label 'foo:'" → look up func
+  | { kind: "unknown" };
+
+/**
+ * Classify a Swift compiler error message and extract the most useful
+ * symbol name for follow-up context lookups.
+ */
+export function classifyError(message: string): ErrorClass {
+  let m: RegExpMatchArray | null;
+
+  // "value of type 'MyModel' has no member 'foo'"
+  // → need to see definition of MyModel
+  m = message.match(/value of type '([^']+)' has no member/);
+  if (m) return { kind: "missing_member", symbol: stripGenerics(m[1]) };
+
+  // "use of unresolved identifier 'fetchUser'"
+  m = message.match(/use of unresolved identifier '([^']+)'/);
+  if (m) return { kind: "unresolved", symbol: m[1] };
+
+  // "cannot find type 'UserModel' in scope"
+  m = message.match(/cannot find type '([^']+)' in scope/);
+  if (m) return { kind: "unresolved", symbol: m[1] };
+
+  // "cannot find 'fetchUser' in scope"
+  m = message.match(/cannot find '([^']+)' in scope/);
+  if (m) return { kind: "unresolved", symbol: m[1] };
+
+  // "referencing instance method 'foo(bar:)' requires..."
+  m = message.match(/referencing (?:instance|static|class) method '([^'(]+)/);
+  if (m) return { kind: "unresolved", symbol: m[1] };
+
+  // "missing argument label 'completion:' in call"
+  m = message.match(/missing argument label '([^':]+)/);
+  if (m) return { kind: "missing_label", symbol: m[1] };
+
+  // "extra argument 'callback' in call"
+  m = message.match(/extra argument '([^']+)' in call/);
+  if (m) return { kind: "missing_label", symbol: m[1] };
+
+  // "cannot convert value of type 'String' to expected argument type 'Int'"
+  // Symbol is unclear from message alone — return null so callers skip lookup
+  if (message.includes("cannot convert value of type") ||
+      message.includes("cannot convert return expression")) {
+    return { kind: "type_mismatch", symbol: null };
+  }
+
+  return { kind: "unknown" };
+}
+
+/** Strip generic parameters from type names, e.g. "Array<String>" → "Array" */
+function stripGenerics(typeName: string): string {
+  return typeName.replace(/<.*>$/, "").trim();
+}

--- a/src/core/sourcekit-lsp.ts
+++ b/src/core/sourcekit-lsp.ts
@@ -1,0 +1,297 @@
+// ============================================================
+// XcodeAutoPilot — Minimal sourcekit-lsp Client
+// JSON-RPC over stdio. Used to resolve definition/references
+// when grep results are ambiguous (≥5 hits).
+// Falls back gracefully if sourcekit-lsp is unavailable.
+// ============================================================
+
+import { spawn, ChildProcess } from "child_process";
+import { readFile } from "fs/promises";
+import { logger } from "../utils/logger.js";
+
+export interface LspLocation {
+  file_path: string;
+  start_line: number;  // 1-indexed
+  end_line: number;    // 1-indexed
+}
+
+// ----------------------------------------------------------
+// LSP Client
+// ----------------------------------------------------------
+
+export class SourceKitLspClient {
+  private proc: ChildProcess | null = null;
+  private readBuffer = "";
+  private pendingRequests = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private nextId = 1;
+  private openedDocs = new Set<string>();
+
+  async initialize(workspaceRoot: string): Promise<void> {
+    this.proc = spawn("xcrun", ["sourcekit-lsp"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    this.proc.stdout!.on("data", (chunk: Buffer) => {
+      this.readBuffer += chunk.toString("utf-8");
+      this.drainBuffer();
+    });
+
+    // Log stderr for debugging but don't throw
+    this.proc.stderr!.on("data", (chunk: Buffer) => {
+      logger.debug(`sourcekit-lsp: ${chunk.toString("utf-8").trim()}`);
+    });
+
+    this.proc.on("error", (err) => {
+      logger.warn(`sourcekit-lsp process error: ${err.message}`);
+    });
+
+    await this.sendRequest(
+      "initialize",
+      {
+        processId: process.pid,
+        rootUri: `file://${workspaceRoot}`,
+        capabilities: {
+          textDocument: {
+            definition: {},
+            references: {},
+          },
+        },
+        workspaceFolders: null,
+      },
+      15_000
+    );
+
+    this.sendNotification("initialized", {});
+  }
+
+  async findDefinition(
+    filePath: string,
+    line: number,
+    col: number
+  ): Promise<LspLocation | null> {
+    await this.openDocument(filePath);
+
+    const result = await this.sendRequest(
+      "textDocument/definition",
+      {
+        textDocument: { uri: toUri(filePath) },
+        position: { line: line - 1, character: col - 1 },
+      },
+      10_000
+    );
+
+    if (!result) return null;
+    const locations = Array.isArray(result) ? result : [result];
+    if (locations.length === 0) return null;
+
+    const loc = locations[0] as LspRawLocation;
+    return {
+      file_path: fromUri(loc.uri),
+      start_line: loc.range.start.line + 1,
+      end_line: loc.range.end.line + 1,
+    };
+  }
+
+  async findReferences(
+    filePath: string,
+    line: number,
+    col: number
+  ): Promise<LspLocation[]> {
+    await this.openDocument(filePath);
+
+    const result = await this.sendRequest(
+      "textDocument/references",
+      {
+        textDocument: { uri: toUri(filePath) },
+        position: { line: line - 1, character: col - 1 },
+        context: { includeDeclaration: false },
+      },
+      15_000
+    );
+
+    if (!Array.isArray(result)) return [];
+
+    return result.slice(0, 10).map((loc: LspRawLocation) => ({
+      file_path: fromUri(loc.uri),
+      start_line: loc.range.start.line + 1,
+      end_line: loc.range.end.line + 1,
+    }));
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.proc) return;
+    try {
+      await this.sendRequest("shutdown", null, 3_000);
+    } catch { /* ignore */ }
+    this.sendNotification("exit", null);
+    this.proc.kill();
+    this.proc = null;
+    this.openedDocs.clear();
+  }
+
+  // ----------------------------------------------------------
+  // Internal: document management
+  // ----------------------------------------------------------
+
+  private async openDocument(filePath: string): Promise<void> {
+    if (this.openedDocs.has(filePath)) return;
+    try {
+      const text = await readFile(filePath, "utf-8");
+      this.sendNotification("textDocument/didOpen", {
+        textDocument: {
+          uri: toUri(filePath),
+          languageId: "swift",
+          version: 1,
+          text,
+        },
+      });
+      this.openedDocs.add(filePath);
+    } catch { /* ignore */ }
+  }
+
+  // ----------------------------------------------------------
+  // Internal: JSON-RPC framing
+  // ----------------------------------------------------------
+
+  private drainBuffer(): void {
+    while (true) {
+      const headerEnd = this.readBuffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) break;
+
+      const header = this.readBuffer.slice(0, headerEnd);
+      const lenMatch = header.match(/Content-Length:\s*(\d+)/i);
+      if (!lenMatch) break;
+
+      const contentLength = parseInt(lenMatch[1], 10);
+      const bodyStart = headerEnd + 4;
+
+      if (this.readBuffer.length < bodyStart + contentLength) break;
+
+      const body = this.readBuffer.slice(bodyStart, bodyStart + contentLength);
+      this.readBuffer = this.readBuffer.slice(bodyStart + contentLength);
+
+      try {
+        const msg = JSON.parse(body) as Record<string, unknown>;
+        if (typeof msg.id === "number") {
+          const pending = this.pendingRequests.get(msg.id);
+          if (pending) {
+            this.pendingRequests.delete(msg.id);
+            if (msg.error) {
+              pending.reject(
+                new Error(
+                  String((msg.error as Record<string, unknown>).message ?? msg.error)
+                )
+              );
+            } else {
+              pending.resolve(msg.result);
+            }
+          }
+        }
+      } catch { /* ignore malformed JSON */ }
+    }
+  }
+
+  private writeMessage(msg: Record<string, unknown>): void {
+    if (!this.proc?.stdin) return;
+    const body = JSON.stringify({ jsonrpc: "2.0", ...msg });
+    const frame = `Content-Length: ${Buffer.byteLength(body, "utf-8")}\r\n\r\n${body}`;
+    this.proc.stdin.write(frame);
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    this.writeMessage({ method, params });
+  }
+
+  private sendRequest(
+    method: string,
+    params: unknown,
+    timeoutMs = 10_000
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.proc) {
+        reject(new Error("LSP process not running"));
+        return;
+      }
+
+      const id = this.nextId++;
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`LSP '${method}' timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, {
+        resolve: (v) => { clearTimeout(timer); resolve(v); },
+        reject: (e) => { clearTimeout(timer); reject(e); },
+      });
+
+      this.writeMessage({ id, method, params });
+    });
+  }
+}
+
+// ----------------------------------------------------------
+// Singleton per workspace root
+// ----------------------------------------------------------
+
+let _client: SourceKitLspClient | null = null;
+let _workspaceRoot: string | null = null;
+
+/**
+ * Get (or create) a shared LSP client for the given workspace.
+ * Returns null if sourcekit-lsp is unavailable or initialization fails.
+ */
+export async function getLspClient(
+  workspaceRoot: string
+): Promise<SourceKitLspClient | null> {
+  if (_client && _workspaceRoot === workspaceRoot) return _client;
+
+  // Different workspace — dispose old client
+  if (_client) {
+    await _client.dispose().catch(() => {});
+    _client = null;
+  }
+
+  const client = new SourceKitLspClient();
+  try {
+    await client.initialize(workspaceRoot);
+    _client = client;
+    _workspaceRoot = workspaceRoot;
+    logger.info(`sourcekit-lsp ready for ${workspaceRoot}`);
+    return client;
+  } catch (err) {
+    logger.warn(`sourcekit-lsp unavailable — falling back to grep: ${String(err)}`);
+    await client.dispose().catch(() => {});
+    return null;
+  }
+}
+
+export async function disposeLspClient(): Promise<void> {
+  if (_client) {
+    await _client.dispose().catch(() => {});
+    _client = null;
+    _workspaceRoot = null;
+  }
+}
+
+// ----------------------------------------------------------
+// URI helpers
+// ----------------------------------------------------------
+
+function toUri(filePath: string): string {
+  return filePath.startsWith("file://") ? filePath : `file://${filePath}`;
+}
+
+function fromUri(uri: string): string {
+  return uri.startsWith("file://") ? uri.slice(7) : uri;
+}
+
+interface LspRawLocation {
+  uri: string;
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+}

--- a/src/core/symbol-searcher.ts
+++ b/src/core/symbol-searcher.ts
@@ -1,0 +1,124 @@
+// ============================================================
+// XcodeAutoPilot — Grep-based Swift Symbol Searcher
+// Finds definitions and call sites for a symbol across .swift files
+// ============================================================
+
+import { exec } from "child_process";
+import { promisify } from "util";
+import { readFile } from "fs/promises";
+import { logger } from "../utils/logger.js";
+
+const execAsync = promisify(exec);
+const GREP_TIMEOUT_MS = 10_000;
+const SNIPPET_RADIUS = 3; // lines before/after the hit
+
+export interface SymbolLocation {
+  file_path: string;
+  line_number: number;   // 1-indexed
+  description: "definition" | "call site";
+  snippet: string;       // formatted ±SNIPPET_RADIUS lines with line numbers
+}
+
+/**
+ * Search for a symbol across all .swift files under projectRoot.
+ * Returns up to maxResults unique locations (definitions first).
+ */
+export async function grepSymbol(
+  symbolName: string,
+  projectRoot: string,
+  maxResults = 10
+): Promise<SymbolLocation[]> {
+  if (!symbolName || symbolName.length < 2) return [];
+
+  const escaped = escapeRegex(symbolName);
+
+  // Run definition and call-site greps in parallel
+  const [defs, calls] = await Promise.allSettled([
+    runGrep(
+      `(func|class|struct|enum|protocol|typealias|extension|actor)\\s+${escaped}\\b`,
+      projectRoot,
+      "definition"
+    ),
+    runGrep(
+      `\\b${escaped}[(<]`,
+      projectRoot,
+      "call site"
+    ),
+  ]);
+
+  const results: SymbolLocation[] = [];
+  if (defs.status === "fulfilled") results.push(...defs.value);
+  if (calls.status === "fulfilled") results.push(...calls.value);
+
+  // Deduplicate by file:line
+  const seen = new Set<string>();
+  const unique = results.filter((r) => {
+    const key = `${r.file_path}:${r.line_number}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  logger.info(`grepSymbol '${symbolName}': ${unique.length} location(s) found`);
+  return unique.slice(0, maxResults);
+}
+
+// ----------------------------------------------------------
+// Internal
+// ----------------------------------------------------------
+
+async function runGrep(
+  pattern: string,
+  root: string,
+  description: "definition" | "call site"
+): Promise<SymbolLocation[]> {
+  try {
+    const cmd = `grep -rn -E "${pattern}" --include="*.swift" "${root}" 2>/dev/null`;
+    const { stdout } = await execAsync(cmd, {
+      timeout: GREP_TIMEOUT_MS,
+      maxBuffer: 5 * 1024 * 1024,
+    });
+
+    const lines = stdout.trim().split("\n").filter(Boolean);
+    const results: SymbolLocation[] = [];
+
+    for (const line of lines.slice(0, 20)) {
+      const match = line.match(/^(.+?):(\d+):/);
+      if (!match) continue;
+
+      const filePath = match[1];
+      const lineNum = parseInt(match[2], 10);
+      const snippet = await buildSnippet(filePath, lineNum);
+
+      results.push({ file_path: filePath, line_number: lineNum, description, snippet });
+    }
+
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+async function buildSnippet(filePath: string, centerLine: number): Promise<string> {
+  try {
+    const content = await readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    const start = Math.max(0, centerLine - 1 - SNIPPET_RADIUS);
+    const end = Math.min(lines.length - 1, centerLine - 1 + SNIPPET_RADIUS);
+
+    return lines
+      .slice(start, end + 1)
+      .map((l, i) => {
+        const n = start + i + 1;
+        const marker = n === centerLine ? ">" : " ";
+        return `${marker} ${String(n).padStart(4)} | ${l}`;
+      })
+      .join("\n");
+  } catch {
+    return "";
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/tools/autopilot-build.ts
+++ b/src/tools/autopilot-build.ts
@@ -4,6 +4,7 @@
 // ============================================================
 
 import { z } from "zod";
+import { dirname } from "path";
 import { runBuild, getDefaultDestination } from "../core/xcodebuild.js";
 import { filterErrors, filterWarnings } from "../core/error-parser.js";
 import { extractContextForDiagnostics } from "../utils/context-extractor.js";
@@ -54,8 +55,9 @@ export async function handleAutopilotBuild(input: AutopilotBuildInput): Promise<
     ? buildResult.diagnostics
     : errors;
 
+  const projectRoot = dirname(input.project_path);
   const contextMap = errors.length > 0
-    ? await extractContextForDiagnostics(diagnosticsForContext)
+    ? await extractContextForDiagnostics(diagnosticsForContext, projectRoot)
     : new Map();
 
   logger.info(`Extracted context for ${contextMap.size} file(s)`);
@@ -67,6 +69,7 @@ export async function handleAutopilotBuild(input: AutopilotBuildInput): Promise<
     source: ctx.context_text,
     start_line: ctx.start_line,
     end_line: ctx.end_line,
+    related_locations: ctx.related_locations,
   }));
 
   return JSON.stringify(

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,18 @@ export interface SessionHistoryEntry {
 }
 
 // ----------------------------------------------------------
+// Context Types
+// ----------------------------------------------------------
+
+export interface RelatedLocation {
+  description: string;   // "function definition" | "call site" | "type definition"
+  file_path: string;
+  snippet: string;       // formatted lines with line numbers
+  start_line: number;
+  end_line: number;
+}
+
+// ----------------------------------------------------------
 // Safety Types
 // ----------------------------------------------------------
 

--- a/src/utils/context-extractor.ts
+++ b/src/utils/context-extractor.ts
@@ -1,20 +1,33 @@
 // ============================================================
 // XcodeAutoPilot — Source Code Context Extractor
+// Hybrid approach:
+//   1. extractEnclosingScope  — find the function/type that wraps the error
+//   2. classifyError          — identify what symbol to look up
+//   3. grepSymbol             — fast cross-file search for definitions/call sites
+//   4. sourcekit-lsp          — precise references when grep is ambiguous (≥5 hits)
 // ============================================================
 
-import { readFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
+import { dirname } from "path";
 import { logger } from "./logger.js";
-import type { BuildDiagnostic } from "../types.js";
-
-const DEFAULT_CONTEXT_LINES = parseInt(
-  process.env.AUTOPILOT_CONTEXT_LINES ?? "50",
-  10
-);
+import type { BuildDiagnostic, RelatedLocation } from "../types.js";
+import { classifyError } from "../core/error-classifier.js";
+import { grepSymbol } from "../core/symbol-searcher.js";
+import { getLspClient } from "../core/sourcekit-lsp.js";
 
 const FILE_SIZE_LIMIT = parseInt(
   process.env.AUTOPILOT_FILE_SIZE_LIMIT ?? "1048576",
   10
 );
+
+// Lines to show on each side when falling back from enclosing scope
+const FALLBACK_CONTEXT_LINES = 50;
+
+// Max lines an enclosing scope can span (prevents giant classes dominating output)
+const MAX_SCOPE_LINES = 150;
+
+// Number of grep results above which we escalate to sourcekit-lsp
+const LSP_ESCALATION_THRESHOLD = 5;
 
 // ----------------------------------------------------------
 // Types
@@ -22,32 +35,108 @@ const FILE_SIZE_LIMIT = parseInt(
 
 export interface FileContext {
   file_path: string;
-  lines: string[];           // Full file lines (0-indexed)
-  error_lines: number[];     // 1-indexed line numbers with errors
-  context_text: string;      // Formatted text with line numbers
-  start_line: number;        // First line of context (1-indexed)
-  end_line: number;          // Last line of context (1-indexed)
+  lines: string[];               // Full file lines (0-indexed)
+  error_lines: number[];         // 1-indexed line numbers with errors
+  context_text: string;          // Formatted text with line numbers
+  start_line: number;            // First line of context (1-indexed)
+  end_line: number;              // Last line of context (1-indexed)
+  related_locations: RelatedLocation[];
 }
 
 // ----------------------------------------------------------
-// Core Functions
+// Enclosing scope extraction
 // ----------------------------------------------------------
 
 /**
- * Read a source file and extract context around multiple error lines.
- * Merges overlapping ranges from multiple errors in the same file.
+ * Find the enclosing function/method/type that contains errorLine.
+ * Uses brace-depth tracking. Falls back to ±FALLBACK_CONTEXT_LINES.
  */
+export function findEnclosingScope(
+  lines: string[],
+  errorLine: number            // 1-indexed
+): { startLine: number; endLine: number } {
+  const totalLines = lines.length;
+  const errorIdx = Math.min(errorLine - 1, totalLines - 1); // 0-indexed
+
+  // Walk backward to find enclosing opening brace
+  let depth = 0;
+  let openBraceIdx = -1;
+
+  for (let i = errorIdx; i >= 0; i--) {
+    const line = lines[i];
+    // Iterate characters in reverse
+    for (let j = line.length - 1; j >= 0; j--) {
+      if (line[j] === "}") depth++;
+      else if (line[j] === "{") {
+        if (depth === 0) {
+          openBraceIdx = i;
+          break;
+        }
+        depth--;
+      }
+    }
+    if (openBraceIdx !== -1) break;
+  }
+
+  if (openBraceIdx === -1) {
+    // No enclosing brace found — use fallback
+    return fallbackRange(errorIdx, totalLines);
+  }
+
+  // Walk backward from openBraceIdx to find the declaration keyword
+  // (func, class, struct, etc.) — check up to 5 lines above
+  const SCOPE_KEYWORDS = /\b(func|init|deinit|subscript|class|struct|enum|protocol|extension|actor|var|let)\b/;
+  let scopeStartIdx = openBraceIdx;
+
+  for (let i = openBraceIdx; i >= Math.max(0, openBraceIdx - 5); i--) {
+    if (SCOPE_KEYWORDS.test(lines[i])) {
+      scopeStartIdx = i;
+      break;
+    }
+  }
+
+  // Walk forward from openBraceIdx to find matching closing brace
+  depth = 0;
+  let scopeEndIdx = Math.min(totalLines - 1, scopeStartIdx + MAX_SCOPE_LINES - 1);
+
+  for (let i = openBraceIdx; i < totalLines && i <= scopeStartIdx + MAX_SCOPE_LINES; i++) {
+    for (const ch of lines[i]) {
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+    }
+    if (depth === 0 && i > openBraceIdx) {
+      scopeEndIdx = i;
+      break;
+    }
+  }
+
+  return { startLine: scopeStartIdx + 1, endLine: scopeEndIdx + 1 };
+}
+
+function fallbackRange(
+  errorIdx: number,
+  totalLines: number
+): { startLine: number; endLine: number } {
+  return {
+    startLine: Math.max(1, errorIdx + 1 - FALLBACK_CONTEXT_LINES),
+    endLine: Math.min(totalLines, errorIdx + 1 + FALLBACK_CONTEXT_LINES),
+  };
+}
+
+// ----------------------------------------------------------
+// Core: extract file context
+// ----------------------------------------------------------
+
 export async function extractFileContext(
   filePath: string,
   errorLines: number[],
-  contextLines: number = DEFAULT_CONTEXT_LINES
+  projectRoot?: string
 ): Promise<FileContext | null> {
   // Safety: check file size
   try {
-    const { stat } = await import("fs/promises");
     const stats = await stat(filePath);
     if (stats.size > FILE_SIZE_LIMIT) {
-      logger.warn(`Skipping context extraction: ${filePath} exceeds size limit (${stats.size} bytes)`);
+      logger.warn(`Skipping context: ${filePath} exceeds size limit`);
       return null;
     }
   } catch {
@@ -58,28 +147,19 @@ export async function extractFileContext(
   try {
     content = await readFile(filePath, "utf-8");
   } catch (err) {
-    logger.warn(`Cannot read file for context: ${filePath} — ${String(err)}`);
+    logger.warn(`Cannot read file: ${filePath} — ${String(err)}`);
     return null;
   }
 
   const lines = content.split("\n");
   const totalLines = lines.length;
-
   if (totalLines === 0) return null;
 
-  // Compute merged range covering all error lines ± context
-  let startLine = Infinity;
-  let endLine = -Infinity;
+  // Find enclosing scope for the first (primary) error line
+  const primaryLine = errorLines[0];
+  const { startLine, endLine } = findEnclosingScope(lines, primaryLine);
 
-  for (const errLine of errorLines) {
-    startLine = Math.min(startLine, errLine - contextLines);
-    endLine = Math.max(endLine, errLine + contextLines);
-  }
-
-  startLine = Math.max(1, startLine);
-  endLine = Math.min(totalLines, endLine);
-
-  // Format context with line numbers: "  42 |     let x: Int = someString"
+  // Format context text with line numbers and error markers
   const contextText = lines
     .slice(startLine - 1, endLine)
     .map((line, i) => {
@@ -97,68 +177,210 @@ export async function extractFileContext(
     context_text: contextText,
     start_line: startLine,
     end_line: endLine,
+    related_locations: [],  // populated below
   };
 }
+
+// ----------------------------------------------------------
+// Related locations: grep + optional LSP
+// ----------------------------------------------------------
+
+async function findRelatedLocations(
+  diagnostic: BuildDiagnostic,
+  projectRoot: string
+): Promise<RelatedLocation[]> {
+  const errorClass = classifyError(diagnostic.message);
+
+  let symbolName: string | null = null;
+  if (errorClass.kind !== "unknown" && errorClass.kind !== "type_mismatch") {
+    symbolName = errorClass.symbol;
+  } else if (errorClass.kind === "type_mismatch" && errorClass.symbol) {
+    symbolName = errorClass.symbol;
+  }
+
+  if (!symbolName) return [];
+
+  // 1. Grep — fast cross-file search
+  const grepResults = await grepSymbol(symbolName, projectRoot);
+
+  // Filter out the error file itself to reduce noise
+  const external = grepResults.filter((r) => r.file_path !== diagnostic.file_path);
+  const sameFile = grepResults.filter((r) => r.file_path === diagnostic.file_path);
+
+  // 2. Escalate to sourcekit-lsp if grep is ambiguous and column info is available
+  if (
+    grepResults.length >= LSP_ESCALATION_THRESHOLD &&
+    diagnostic.column_number &&
+    diagnostic.line_number
+  ) {
+    const lsp = await getLspClient(projectRoot).catch(() => null);
+    if (lsp) {
+      try {
+        const [def, refs] = await Promise.allSettled([
+          lsp.findDefinition(diagnostic.file_path, diagnostic.line_number, diagnostic.column_number),
+          lsp.findReferences(diagnostic.file_path, diagnostic.line_number, diagnostic.column_number),
+        ]);
+
+        const lspLocations: RelatedLocation[] = [];
+
+        if (def.status === "fulfilled" && def.value) {
+          const snippet = await buildSnippetFromFile(def.value.file_path, def.value.start_line, 5);
+          lspLocations.push({
+            description: "definition (lsp)",
+            file_path: def.value.file_path,
+            snippet,
+            start_line: def.value.start_line,
+            end_line: def.value.end_line,
+          });
+        }
+
+        if (refs.status === "fulfilled" && refs.value.length > 0) {
+          for (const ref of refs.value.slice(0, 5)) {
+            const snippet = await buildSnippetFromFile(ref.file_path, ref.start_line, 3);
+            lspLocations.push({
+              description: "call site (lsp)",
+              file_path: ref.file_path,
+              snippet,
+              start_line: ref.start_line,
+              end_line: ref.end_line,
+            });
+          }
+        }
+
+        if (lspLocations.length > 0) {
+          logger.info(`LSP found ${lspLocations.length} location(s) for '${symbolName}'`);
+          return lspLocations;
+        }
+      } catch (err) {
+        logger.warn(`LSP query failed, using grep results: ${String(err)}`);
+      }
+    }
+  }
+
+  // 3. Use grep results (prefer external files, then same-file)
+  return [...external, ...sameFile].slice(0, 6).map((loc) => ({
+    description: loc.description === "definition"
+      ? "function definition"
+      : "call site",
+    file_path: loc.file_path,
+    snippet: loc.snippet,
+    start_line: loc.line_number,
+    end_line: loc.line_number,
+  }));
+}
+
+async function buildSnippetFromFile(
+  filePath: string,
+  centerLine: number,
+  radius: number
+): Promise<string> {
+  try {
+    const content = await readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    const start = Math.max(0, centerLine - 1 - radius);
+    const end = Math.min(lines.length - 1, centerLine - 1 + radius);
+
+    return lines
+      .slice(start, end + 1)
+      .map((l, i) => {
+        const n = start + i + 1;
+        const marker = n === centerLine ? ">" : " ";
+        return `${marker} ${String(n).padStart(4)} | ${l}`;
+      })
+      .join("\n");
+  } catch {
+    return "";
+  }
+}
+
+// ----------------------------------------------------------
+// Public API: extract context for all diagnostics
+// ----------------------------------------------------------
 
 /**
  * Extract context for all unique files mentioned in diagnostics.
  * Returns a map from file_path → FileContext.
+ *
+ * @param projectRoot  Optional. When provided, enables grep + LSP lookup
+ *                     for related locations (definitions, call sites).
  */
 export async function extractContextForDiagnostics(
-  diagnostics: BuildDiagnostic[]
+  diagnostics: BuildDiagnostic[],
+  projectRoot?: string
 ): Promise<Map<string, FileContext>> {
-  // Group error line numbers by file path
+  // Group error line numbers and diagnostics by file path
   const fileErrorLines = new Map<string, number[]>();
+  const fileDiagnostics = new Map<string, BuildDiagnostic[]>();
 
   for (const diag of diagnostics) {
     if (!diag.file_path || diag.line_number === 0) continue;
-    const existing = fileErrorLines.get(diag.file_path) ?? [];
-    if (!existing.includes(diag.line_number)) {
-      existing.push(diag.line_number);
-    }
-    fileErrorLines.set(diag.file_path, existing);
+
+    const lines = fileErrorLines.get(diag.file_path) ?? [];
+    if (!lines.includes(diag.line_number)) lines.push(diag.line_number);
+    fileErrorLines.set(diag.file_path, lines);
+
+    const diags = fileDiagnostics.get(diag.file_path) ?? [];
+    diags.push(diag);
+    fileDiagnostics.set(diag.file_path, diags);
   }
 
   // Extract context for each file in parallel
   const entries = Array.from(fileErrorLines.entries());
   const results = await Promise.all(
     entries.map(async ([filePath, errorLines]) => {
-      const ctx = await extractFileContext(filePath, errorLines);
+      const ctx = await extractFileContext(filePath, errorLines, projectRoot);
+      if (!ctx) return [filePath, null] as const;
+
+      // Fetch related locations if projectRoot is available
+      if (projectRoot) {
+        const diagsForFile = fileDiagnostics.get(filePath) ?? [];
+        const root = projectRoot ?? dirname(filePath);
+
+        // Gather related locations from all diagnostics in this file
+        const allRelated = await Promise.all(
+          diagsForFile.map((d) => findRelatedLocations(d, root))
+        );
+
+        // Deduplicate related locations
+        const seen = new Set<string>();
+        ctx.related_locations = allRelated
+          .flat()
+          .filter((r) => {
+            const key = `${r.file_path}:${r.start_line}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          });
+      }
+
       return [filePath, ctx] as const;
     })
   );
 
   const contextMap = new Map<string, FileContext>();
   for (const [filePath, ctx] of results) {
-    if (ctx !== null) {
-      contextMap.set(filePath, ctx);
-    }
+    if (ctx !== null) contextMap.set(filePath, ctx);
   }
 
   return contextMap;
 }
 
-/**
- * Get a single line from a file (1-indexed).
- * Returns null if file cannot be read or line doesn't exist.
- */
+// ----------------------------------------------------------
+// Utility helpers (retained from original)
+// ----------------------------------------------------------
+
 export async function getFileLine(
   filePath: string,
   lineNumber: number
 ): Promise<string | null> {
   try {
     const content = await readFile(filePath, "utf-8");
-    const lines = content.split("\n");
-    const line = lines[lineNumber - 1];
-    return line ?? null;
+    return content.split("\n")[lineNumber - 1] ?? null;
   } catch {
     return null;
   }
 }
 
-/**
- * Get all lines of a file (for patching).
- */
 export async function getFileLines(filePath: string): Promise<string[] | null> {
   try {
     const content = await readFile(filePath, "utf-8");


### PR DESCRIPTION
## Summary

- ±50줄 고정 윈도우를 **3단계 Hybrid 전략**으로 교체
- `file_contexts`에 `related_locations[]` 필드 추가 — 에러 위치 외에 정의/호출부도 함께 반환

## How it works

1. **Enclosing scope** — 중괄호 depth 트래킹으로 에러를 감싼 func/class/struct 전체 반환 (최대 150줄)
2. **Grep** — 에러 메시지 분류 → 심볼명 추출 → 프로젝트 .swift 전체에서 정의 + 호출부 탐색
3. **sourcekit-lsp** — grep 결과 ≥5개 + column 정보 있을 때 `xcrun sourcekit-lsp`로 정밀 조회, 실패 시 grep fallback

## New files

| File | Purpose |
|------|---------|
| `src/core/error-classifier.ts` | Swift 에러 패턴 분류 + 심볼 추출 |
| `src/core/symbol-searcher.ts` | grep 기반 크로스파일 심볼 탐색 |
| `src/core/sourcekit-lsp.ts` | JSON-RPC stdio LSP 클라이언트 |

## Test plan

- [x] `npm run build` 통과
- [x] `npm test` 42/42 통과
- [ ] `autopilot_build` 호출 → `file_contexts[].related_locations` 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)