### PR TITLE
feat: autopilot_screenshot — simulator screenshot with AI vision

### DIFF
--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -4,7 +4,6 @@
 
 import { exec } from "child_process";
 import { promisify } from "util";
-import { readdirSync } from "fs";
 import { logger } from "../utils/logger.js";
 
 const execAsync = promisify(exec);
@@ -81,15 +80,20 @@ export async function findSimulator(
 // ----------------------------------------------------------
 
 export async function bootSimulator(udid: string): Promise<void> {
+  // Open Simulator.app first — required for screen surface rendering (screenshot)
+  execAsync("open -a Simulator").catch(() => {});
+
   try {
     await execAsync(`xcrun simctl boot "${udid}"`, { timeout: 60_000 });
     logger.info(`Booted simulator: ${udid}`);
-    // Brief wait for Springboard to settle
-    await new Promise((r) => setTimeout(r, 2_000));
+    // Wait for Springboard to settle and screen surfaces to become available
+    await new Promise((r) => setTimeout(r, 4_000));
   } catch (err) {
     const msg = String(err);
     if (msg.includes("current state: Booted") || msg.includes("already booted")) {
       logger.info(`Simulator already booted: ${udid}`);
+      // Brief wait in case Simulator.app was just opened
+      await new Promise((r) => setTimeout(r, 2_000));
     } else {
       throw err;
     }
@@ -126,38 +130,59 @@ export async function launchApp(udid: string, bundleId: string): Promise<void> {
 // Take screenshot
 // ----------------------------------------------------------
 
-export async function takeScreenshot(udid: string, outputPath: string): Promise<void> {
-  await execAsync(`xcrun simctl io "${udid}" screenshot "${outputPath}"`, { timeout: 30_000 });
-  logger.info(`Screenshot saved: ${outputPath}`);
+const FIND_WINDOW_SWIFT = `
+import Cocoa
+let windows = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as! [[String: Any]]
+for w in windows {
+    let owner = w["kCGWindowOwnerName"] as? String ?? ""
+    let name = w["kCGWindowName"] as? String ?? ""
+    let wid = w["kCGWindowNumber"] as? Int ?? 0
+    if owner == "Simulator" && !name.isEmpty {
+        print(wid)
+        exit(0)
+    }
 }
+exit(1)
+`;
 
-// ----------------------------------------------------------
-// Find built .app bundle in DerivedData
-// ----------------------------------------------------------
-
-export function findBuiltApp(
-  derivedDataPath: string,
-  configuration: string
-): string {
-  const productsDir = `${derivedDataPath}/Build/Products/${configuration}-iphonesimulator`;
-
-  let entries: string[];
+export async function takeScreenshot(deviceName: string, outputPath: string): Promise<void> {
+  // First try simctl io screenshot (works on non-beta iOS)
   try {
-    entries = readdirSync(productsDir);
+    // Find the booted simulator UDID by name for simctl
+    const { stdout: simctlOut } = await execAsync(
+      "xcrun simctl list devices booted --json",
+      { timeout: 10_000 }
+    );
+    const data = JSON.parse(simctlOut) as { devices: Record<string, SimDevice[]> };
+    let udid = "";
+    for (const devices of Object.values(data.devices)) {
+      const match = devices.find((d) => d.name === deviceName);
+      if (match) { udid = match.udid; break; }
+    }
+    if (udid) {
+      await execAsync(`xcrun simctl io "${udid}" screenshot "${outputPath}"`, { timeout: 15_000 });
+      logger.info(`Screenshot saved via simctl: ${outputPath}`);
+      return;
+    }
   } catch {
+    logger.warn("simctl io screenshot failed, falling back to window capture");
+  }
+
+  // Fallback: find Simulator window via CGWindowList and screencapture
+  const swiftCode = FIND_WINDOW_SWIFT.trim();
+  const { stdout: widOut } = await execAsync(
+    `echo '${swiftCode.replace(/'/g, "'\\''")}' | swift -`,
+    { timeout: 20_000, shell: "/bin/zsh" }
+  ).catch(() => ({ stdout: "" }));
+
+  const wid = parseInt(widOut.trim(), 10);
+  if (!wid || isNaN(wid)) {
     throw new Error(
-      `Build products directory not found: ${productsDir}. ` +
-      `Ensure the build succeeded and configuration matches (e.g. "Debug").`
+      "Could not find Simulator window. Ensure Simulator.app is open and the device window is visible."
     );
   }
 
-  const apps = entries
-    .filter((e) => e.endsWith(".app"))
-    .map((e) => `${productsDir}/${e}`);
-
-  if (apps.length === 0) {
-    throw new Error(`No .app bundle found in: ${productsDir}`);
-  }
-
-  return apps[0];
+  await execAsync(`screencapture -l ${wid} -x "${outputPath}"`, { timeout: 15_000 });
+  logger.info(`Screenshot saved via screencapture (wid=${wid}): ${outputPath}`);
 }
+

--- a/src/core/simulator.ts
+++ b/src/core/simulator.ts
@@ -1,0 +1,163 @@
+// ============================================================
+// XcodeAutoPilot — iOS Simulator Utilities
+// ============================================================
+
+import { exec } from "child_process";
+import { promisify } from "util";
+import { readdirSync } from "fs";
+import { logger } from "../utils/logger.js";
+
+const execAsync = promisify(exec);
+
+// ----------------------------------------------------------
+// Types
+// ----------------------------------------------------------
+
+export interface SimDevice {
+  name: string;
+  udid: string;
+  state: string;
+  isAvailable: boolean;
+}
+
+interface SimctlOutput {
+  devices: Record<string, SimDevice[]>;
+}
+
+// ----------------------------------------------------------
+// Find simulator
+// ----------------------------------------------------------
+
+export async function findSimulator(
+  deviceName: string,
+  osVersion?: string
+): Promise<SimDevice> {
+  const { stdout } = await execAsync(
+    "xcrun simctl list devices available --json",
+    { timeout: 15_000 }
+  );
+  const data = JSON.parse(stdout) as SimctlOutput;
+
+  const runtimeFilter = osVersion
+    ? osVersion.replace(/\./g, "-")
+    : null;
+
+  // Prefer exact name match first, then partial
+  let fallback: SimDevice | null = null;
+
+  for (const [runtime, devices] of Object.entries(data.devices)) {
+    if (runtimeFilter && !runtime.includes(runtimeFilter)) continue;
+    for (const device of devices) {
+      if (!device.isAvailable) continue;
+      if (device.name === deviceName) return device;
+      if (device.name.includes(deviceName) && !fallback) {
+        fallback = device;
+      }
+    }
+  }
+
+  if (fallback) return fallback;
+
+  // Last resort: any available iPhone if deviceName contains "iPhone"
+  if (deviceName.toLowerCase().includes("iphone")) {
+    for (const [, devices] of Object.entries(data.devices)) {
+      for (const device of devices) {
+        if (device.isAvailable && device.name.includes("iPhone")) {
+          logger.warn(`Simulator "${deviceName}" not found, using "${device.name}" instead`);
+          return device;
+        }
+      }
+    }
+  }
+
+  throw new Error(
+    `Simulator not found: "${deviceName}"${osVersion ? ` (iOS ${osVersion})` : ""}. ` +
+    `Run 'xcrun simctl list devices available' to see available simulators.`
+  );
+}
+
+// ----------------------------------------------------------
+// Boot simulator
+// ----------------------------------------------------------
+
+export async function bootSimulator(udid: string): Promise<void> {
+  try {
+    await execAsync(`xcrun simctl boot "${udid}"`, { timeout: 60_000 });
+    logger.info(`Booted simulator: ${udid}`);
+    // Brief wait for Springboard to settle
+    await new Promise((r) => setTimeout(r, 2_000));
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("current state: Booted") || msg.includes("already booted")) {
+      logger.info(`Simulator already booted: ${udid}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+// ----------------------------------------------------------
+// Install app
+// ----------------------------------------------------------
+
+export async function installApp(udid: string, appPath: string): Promise<void> {
+  await execAsync(`xcrun simctl install "${udid}" "${appPath}"`, { timeout: 60_000 });
+  logger.info(`Installed: ${appPath}`);
+}
+
+// ----------------------------------------------------------
+// Launch app
+// ----------------------------------------------------------
+
+export async function launchApp(udid: string, bundleId: string): Promise<void> {
+  // --terminate-running-simulation ensures a fresh launch
+  try {
+    await execAsync(`xcrun simctl terminate "${udid}" "${bundleId}" 2>/dev/null || true`, {
+      timeout: 10_000,
+    });
+  } catch {
+    // Ignore terminate errors — app may not have been running
+  }
+  await execAsync(`xcrun simctl launch "${udid}" "${bundleId}"`, { timeout: 30_000 });
+  logger.info(`Launched: ${bundleId}`);
+}
+
+// ----------------------------------------------------------
+// Take screenshot
+// ----------------------------------------------------------
+
+export async function takeScreenshot(udid: string, outputPath: string): Promise<void> {
+  await execAsync(`xcrun simctl io "${udid}" screenshot "${outputPath}"`, { timeout: 30_000 });
+  logger.info(`Screenshot saved: ${outputPath}`);
+}
+
+// ----------------------------------------------------------
+// Find built .app bundle in DerivedData
+// ----------------------------------------------------------
+
+export function findBuiltApp(
+  derivedDataPath: string,
+  configuration: string
+): string {
+  const productsDir = `${derivedDataPath}/Build/Products/${configuration}-iphonesimulator`;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(productsDir);
+  } catch {
+    throw new Error(
+      `Build products directory not found: ${productsDir}. ` +
+      `Ensure the build succeeded and configuration matches (e.g. "Debug").`
+    );
+  }
+
+  const apps = entries
+    .filter((e) => e.endsWith(".app"))
+    .map((e) => `${productsDir}/${e}`);
+
+  if (apps.length === 0) {
+    throw new Error(`No .app bundle found in: ${productsDir}`);
+  }
+
+  return apps[0];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { handleClean, cleanSchema } from "./tools/clean.js";
 import { handleHistory } from "./tools/history.js";
 import { handleCacheClean, cacheClearSchema } from "./tools/cache-clean.js";
 import { handleAutopilotTuistBuild, autopilotTuistBuildSchema } from "./tools/tuist-build.js";
+import { handleAutopilotScreenshot, autopilotScreenshotSchema } from "./tools/screenshot.js";
 
 // ----------------------------------------------------------
 // Tool definitions (for ListTools response)
@@ -75,6 +76,14 @@ const TOOLS = [
       "Then runs xcodebuild and returns structured errors with source context, same format as autopilot_build. " +
       "Use skip_install or skip_generate to skip steps already completed.",
     inputSchema: zodToJsonSchema(autopilotTuistBuildSchema),
+  },
+  {
+    name: "autopilot_screenshot",
+    description:
+      "Build the app, run it in an iOS simulator, and capture a screenshot. " +
+      "Returns the screenshot as an image so Claude can visually inspect the UI. " +
+      "Also saves the PNG to <project>/.xap/screenshots/ and opens it in macOS Preview.",
+    inputSchema: zodToJsonSchema(autopilotScreenshotSchema),
   },
   {
     name: "autopilot_history",
@@ -152,6 +161,8 @@ export function createServer(): Server {
 
     try {
       let result: string;
+      let imageBase64: string | undefined;
+      let imageMimeType: string | undefined;
 
       switch (name) {
         case "autopilot_build": {
@@ -189,6 +200,14 @@ export function createServer(): Server {
           result = await handleAutopilotTuistBuild(parsed);
           break;
         }
+        case "autopilot_screenshot": {
+          const parsed = autopilotScreenshotSchema.parse(args);
+          const screenshotResult = await handleAutopilotScreenshot(parsed);
+          result = screenshotResult.text;
+          imageBase64 = screenshotResult.imageBase64;
+          imageMimeType = screenshotResult.mimeType;
+          break;
+        }
         case "autopilot_history": {
           result = await handleHistory();
           break;
@@ -197,7 +216,13 @@ export function createServer(): Server {
           throw new Error(`Unknown tool: ${name}`);
       }
 
-      return { content: [{ type: "text", text: result }] };
+      const content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> = [
+        { type: "text", text: result },
+      ];
+      if (imageBase64 && imageMimeType) {
+        content.push({ type: "image", data: imageBase64, mimeType: imageMimeType });
+      }
+      return { content };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(`Tool error (${name}): ${message}`);

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,0 +1,167 @@
+// ============================================================
+// XcodeAutoPilot — autopilot_screenshot Tool
+// Builds app, runs in simulator, captures screenshot for AI vision
+// ============================================================
+
+import { z } from "zod";
+import { mkdirSync, readFileSync } from "fs";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { dirname, join } from "path";
+import { runBuild } from "../core/xcodebuild.js";
+import {
+  findSimulator,
+  bootSimulator,
+  installApp,
+  launchApp,
+  takeScreenshot,
+  findBuiltApp,
+} from "../core/simulator.js";
+import { logger } from "../utils/logger.js";
+
+const execAsync = promisify(exec);
+
+// ----------------------------------------------------------
+// Schema
+// ----------------------------------------------------------
+
+export const autopilotScreenshotSchema = z.object({
+  project_path: z
+    .string()
+    .describe("Absolute path to .xcodeproj or .xcworkspace"),
+  scheme: z.string().describe("Build scheme name"),
+  bundle_id: z
+    .string()
+    .describe("App bundle identifier (e.g. com.example.MyApp)"),
+  device_name: z
+    .string()
+    .optional()
+    .default("iPhone 16")
+    .describe("Simulator device name (default: iPhone 16)"),
+  os_version: z
+    .string()
+    .optional()
+    .describe("iOS version filter (e.g. '18.0'). Auto-detected if omitted."),
+  configuration: z
+    .string()
+    .optional()
+    .default("Debug")
+    .describe("Build configuration (default: Debug)"),
+  launch_wait_seconds: z
+    .number()
+    .optional()
+    .default(2)
+    .describe("Seconds to wait after app launch before taking screenshot (default: 2)"),
+  open_preview: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe("Open screenshot in macOS Preview after capture (default: true)"),
+});
+
+export type AutopilotScreenshotInput = z.infer<typeof autopilotScreenshotSchema>;
+
+// ----------------------------------------------------------
+// Result type (includes image for MCP response)
+// ----------------------------------------------------------
+
+export interface ScreenshotResult {
+  text: string;
+  imageBase64: string;
+  mimeType: "image/png";
+}
+
+// ----------------------------------------------------------
+// Handler
+// ----------------------------------------------------------
+
+export async function handleAutopilotScreenshot(
+  input: AutopilotScreenshotInput
+): Promise<ScreenshotResult> {
+  logger.info(
+    `autopilot_screenshot: ${input.project_path} [${input.scheme}] on ${input.device_name}`
+  );
+
+  const projectRoot = dirname(input.project_path);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const derivedDataPath = `/tmp/xap-build-${timestamp}`;
+
+  // Prepare screenshots output directory
+  const screenshotsDir = join(projectRoot, ".xap", "screenshots");
+  mkdirSync(screenshotsDir, { recursive: true });
+  const screenshotPath = join(screenshotsDir, `${timestamp}.png`);
+
+  // ── Step 1: Find simulator ──────────────────────────────
+  logger.info(`Finding simulator: ${input.device_name}`);
+  const device = await findSimulator(input.device_name, input.os_version);
+  logger.info(`Found: ${device.name} (${device.udid})`);
+
+  // ── Step 2: Boot simulator ──────────────────────────────
+  await bootSimulator(device.udid);
+
+  // ── Step 3: Build for simulator ─────────────────────────
+  logger.info("Building for simulator...");
+  const destination = `platform=iOS Simulator,id=${device.udid}`;
+  const buildResult = await runBuild({
+    project_path: input.project_path,
+    scheme: input.scheme,
+    configuration: input.configuration,
+    destination,
+    derived_data_path: derivedDataPath,
+  });
+
+  if (!buildResult.success) {
+    const errors = buildResult.diagnostics
+      .filter((d) => d.type === "error")
+      .slice(0, 5)
+      .map((d) => `  • ${d.file_path}:${d.line_number} — ${d.message}`)
+      .join("\n");
+    throw new Error(
+      `Build failed with ${buildResult.diagnostics.filter((d) => d.type === "error").length} error(s):\n${errors}\n\nRun autopilot_build first to fix errors.`
+    );
+  }
+
+  // ── Step 4: Find built .app ─────────────────────────────
+  const appPath = findBuiltApp(derivedDataPath, input.configuration ?? "Debug");
+  logger.info(`App: ${appPath}`);
+
+  // ── Step 5: Install app ─────────────────────────────────
+  await installApp(device.udid, appPath);
+
+  // ── Step 6: Launch app ──────────────────────────────────
+  await launchApp(device.udid, input.bundle_id);
+
+  // ── Step 7: Wait for app to load ────────────────────────
+  const waitMs = (input.launch_wait_seconds ?? 2) * 1000;
+  logger.info(`Waiting ${waitMs}ms for app to load...`);
+  await new Promise((r) => setTimeout(r, waitMs));
+
+  // ── Step 8: Take screenshot ─────────────────────────────
+  await takeScreenshot(device.udid, screenshotPath);
+
+  // ── Step 9: Open in Preview (non-blocking) ───────────────
+  if (input.open_preview !== false) {
+    execAsync(`open "${screenshotPath}"`).catch(() => {
+      // Non-critical — don't fail if open fails
+    });
+  }
+
+  // ── Step 10: Read image as base64 ───────────────────────
+  const imageBase64 = readFileSync(screenshotPath).toString("base64");
+
+  const text = JSON.stringify(
+    {
+      success: true,
+      device: device.name,
+      udid: device.udid,
+      bundle_id: input.bundle_id,
+      screenshot_path: screenshotPath,
+      build_duration_seconds: buildResult.duration_seconds,
+      message: "Screenshot captured. The image is included in this response for visual analysis.",
+    },
+    null,
+    2
+  );
+
+  return { text, imageBase64, mimeType: "image/png" };
+}

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -4,7 +4,7 @@
 // ============================================================
 
 import { z } from "zod";
-import { mkdirSync, readFileSync } from "fs";
+import { mkdirSync, readFileSync, readdirSync } from "fs";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { dirname, join } from "path";
@@ -15,7 +15,6 @@ import {
   installApp,
   launchApp,
   takeScreenshot,
-  findBuiltApp,
 } from "../core/simulator.js";
 import { logger } from "../utils/logger.js";
 
@@ -72,6 +71,58 @@ export interface ScreenshotResult {
 }
 
 // ----------------------------------------------------------
+// Get BUILT_PRODUCTS_DIR from xcodebuild -showBuildSettings
+// ----------------------------------------------------------
+
+async function getBuiltProductsDir(
+  projectPath: string,
+  scheme: string,
+  configuration: string,
+  destination: string
+): Promise<string> {
+  const flag = projectPath.endsWith(".xcworkspace") ? "-workspace" : "-project";
+  const cmd = [
+    "xcodebuild",
+    flag, `"${projectPath}"`,
+    "-scheme", `"${scheme}"`,
+    "-configuration", configuration,
+    "-destination", `'${destination}'`,
+    "-showBuildSettings",
+    "2>/dev/null",
+  ].join(" ");
+
+  const { stdout } = await execAsync(cmd, { timeout: 30_000 });
+
+  const match = stdout.match(/^\s*BUILT_PRODUCTS_DIR\s*=\s*(.+)$/m);
+  if (!match) {
+    throw new Error("Could not determine BUILT_PRODUCTS_DIR from xcodebuild -showBuildSettings");
+  }
+  return match[1].trim();
+}
+
+// ----------------------------------------------------------
+// Find .app bundle in a products directory
+// ----------------------------------------------------------
+
+function findAppInDir(productsDir: string): string {
+  let entries: string[];
+  try {
+    entries = readdirSync(productsDir);
+  } catch {
+    throw new Error(`Build products directory not found: ${productsDir}`);
+  }
+
+  const apps = entries
+    .filter((e) => e.endsWith(".app"))
+    .map((e) => join(productsDir, e));
+
+  if (apps.length === 0) {
+    throw new Error(`No .app bundle found in: ${productsDir}`);
+  }
+  return apps[0];
+}
+
+// ----------------------------------------------------------
 // Handler
 // ----------------------------------------------------------
 
@@ -84,7 +135,7 @@ export async function handleAutopilotScreenshot(
 
   const projectRoot = dirname(input.project_path);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const derivedDataPath = `/tmp/xap-build-${timestamp}`;
+  const configuration = input.configuration ?? "Debug";
 
   // Prepare screenshots output directory
   const screenshotsDir = join(projectRoot, ".xap", "screenshots");
@@ -96,18 +147,18 @@ export async function handleAutopilotScreenshot(
   const device = await findSimulator(input.device_name, input.os_version);
   logger.info(`Found: ${device.name} (${device.udid})`);
 
+  const destination = `platform=iOS Simulator,name=${device.name}`;
+
   // ── Step 2: Boot simulator ──────────────────────────────
   await bootSimulator(device.udid);
 
   // ── Step 3: Build for simulator ─────────────────────────
   logger.info("Building for simulator...");
-  const destination = `platform=iOS Simulator,id=${device.udid}`;
   const buildResult = await runBuild({
     project_path: input.project_path,
     scheme: input.scheme,
-    configuration: input.configuration,
+    configuration,
     destination,
-    derived_data_path: derivedDataPath,
   });
 
   if (!buildResult.success) {
@@ -121,8 +172,15 @@ export async function handleAutopilotScreenshot(
     );
   }
 
-  // ── Step 4: Find built .app ─────────────────────────────
-  const appPath = findBuiltApp(derivedDataPath, input.configuration ?? "Debug");
+  // ── Step 4: Locate built .app via build settings ─────────
+  logger.info("Locating built .app...");
+  const builtProductsDir = await getBuiltProductsDir(
+    input.project_path,
+    input.scheme,
+    configuration,
+    destination
+  );
+  const appPath = findAppInDir(builtProductsDir);
   logger.info(`App: ${appPath}`);
 
   // ── Step 5: Install app ─────────────────────────────────
@@ -137,7 +195,7 @@ export async function handleAutopilotScreenshot(
   await new Promise((r) => setTimeout(r, waitMs));
 
   // ── Step 8: Take screenshot ─────────────────────────────
-  await takeScreenshot(device.udid, screenshotPath);
+  await takeScreenshot(device.name, screenshotPath);
 
   // ── Step 9: Open in Preview (non-blocking) ───────────────
   if (input.open_preview !== false) {


### PR DESCRIPTION
## Summary

- Builds the app for an iOS simulator target
- Boots simulator if not running
- Installs and launches the app
- Waits configurable seconds for app to load
- Captures PNG via `xcrun simctl io screenshot`
- Saves to `<project>/.xap/screenshots/<timestamp>.png`
- Opens in macOS Preview for the user
- Returns base64 image in MCP response → Claude can visually analyze the UI

## Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `project_path` | — | Path to `.xcodeproj` / `.xcworkspace` |
| `scheme` | — | Build scheme |
| `bundle_id` | — | App bundle identifier |
| `device_name` | `iPhone 16` | Simulator device name |
| `os_version` | auto | iOS version filter |
| `configuration` | `Debug` | Build configuration |
| `launch_wait_seconds` | `2` | Wait after launch before screenshot |
| `open_preview` | `true` | Open in macOS Preview |

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npm run test:run` — 42/42 passed

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)